### PR TITLE
Remove setup_version

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="MageSuite_Magepack" setup_version="1.0.0">
+    <module name="MageSuite_Magepack">
         <sequence></sequence>
     </module>
 </config>


### PR DESCRIPTION
The `setup_version` is only required when there is an actual setup to run.