### PR TITLE
The "as" attribute should not be used for links that are prefetched.

### DIFF
--- a/view/frontend/templates/bundles-loader.phtml
+++ b/view/frontend/templates/bundles-loader.phtml
@@ -7,11 +7,11 @@ $prefetchBundlesUrls = $block->getPrefetchBundlesUrls();
 ?>
 
 <?php if ($commonBundleUrl): ?>
-<link rel="prefetch" as="script" href="<?= $commonBundleUrl; ?>"/>
+<link rel="prefetch" href="<?= $commonBundleUrl; ?>"/>
 <?php endif; ?>
 
 <?php foreach($pageBundlesUrls as $pageBundleUrl): ?>
-<link rel="prefetch" as="script" href="<?= $pageBundleUrl; ?>"/>
+<link rel="prefetch" href="<?= $pageBundleUrl; ?>"/>
 <?php endforeach; ?>
 
 <?php if (!empty($prefetchBundlesUrls)): ?>


### PR DESCRIPTION
"as" is purely a rel="preload" attribute.

Fixes HTML validation error:

    Error: A link element with an as attribute must have a rel attribute that contains the value preload.

    From line 22, column 1; to line 22, column 158
    <link rel="prefetch" as="script" href="https://staticshop.example.com/static/version1614655022/frontend/Example/default/en_US/magepack/bundle-common.min.js" />

Also see https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ